### PR TITLE
Fixing Invalid Terraform Configuration

### DIFF
--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -107,7 +107,7 @@ curl -sfL \
     -H "Authorization: Bearer $(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" \
     -H "Content-Type: application/vnd.api+json" \
     -X POST \
-    -d '{"data":{"type":"vars","attributes":{"key":"google_credentials","value":"'$(base64 "$HOME/.config/gcloud/gcp-project-credentials.json")'","description":"Base64 encoded GCP Service Account used to manage GCP resources","category":"terraform","sensitive":true}}}' \
+    -d '{"data":{"type":"vars","attributes":{"key":"google_credentials","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n' | base64)'","description":"Base64 encoded GCP Service Account used to manage GCP resources","category":"terraform","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
 # Remove the Service Account Key from the local filesystem now that it has been


### PR DESCRIPTION
This Pull Request fixes Issue #3

### Change Description
The **initial-setup.sh** script was taking a JSON encoded file and using the base64 command to encode its content and  saving it as a Terraform Cloud Variable, named **google_credentials** in the bootstrap Workspace. The problem arose, when that variable was used as the value for an attribute that cannot accept newlines in its value.

To solve this problem, the JSON encoded file was simply stripped of its newline characters before being base64 encoded.  Since JSON encoding does not require newline characters, this elegant solution required only a small change.
