### PR TITLE
Consolidating Resources from gcp-project Repositories into this Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ variable "terraform_cloud_oauth_token_id" {
 
 ## Regular Configuration
 
+When commits are pushed to the *main* branch, Terraform Cloud will automatically trigger a Terraform run.  However, an authorized operator will need to approve the plan prior to it being applied.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ GCP Projects are identified in two ways:
 
 By convention, project names will use all uppercase letters and hyphens, and project IDs will be the same as the name but using only lowercase letters and followed by a hyphen and a six digit sequence.  Since APIs and tools refer to GCP Projects by their ID not their name, the name is never used elsewhere (e.g. as part of the name of other resources).  Whenever a reference back to the GCP Project is needed, the Project ID is used.
 
-Currently, the projects have been created with the following attributes, however if reconstructing them in a disaster recovery scenario, it is possible that these project ID values are no longer available, in which case, a different six digit sequence should be used and the corresponding variable named **gcp_projects** in the **terraform/gcp.tf** file and this README should be updated.
+Currently, the projects have been created with the following attributes, however if reconstructing them in a disaster recovery scenario, it is possible that these project ID values are no longer available, in which case, a different six digit sequence should be used and the corresponding variable named **gcp_project_suffix** in the **terraform/gcp.tf** file and this README should be updated.
 
 | Project Name   | Project ID            | Purpose            |
 | -------------- | --------------------- | ------------------ |

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -14,7 +14,7 @@
 #   given gcloud command.
 #
 function gcloud {
-    docker run --rm -it -v $HOME/.config/gcloud:/root/.config/gcloud -w /root \
+    docker run --rm -it -v $temp_directory:/data -v $HOME/.config/gcloud:/root/.config/gcloud -w /root \
         gcr.io/google.com/cloudsdktool/cloud-sdk:slim gcloud "$@"
 }
 

--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -107,7 +107,7 @@ curl -sfL \
     -H "Authorization: Bearer $(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" \
     -H "Content-Type: application/vnd.api+json" \
     -X POST \
-    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n' | base64)'","description":"Base64 encoded GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
+    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n')'","description":"GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
 # Remove the Service Account Key from the local filesystem now that it has been

--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -107,7 +107,7 @@ curl -sfL \
     -H "Authorization: Bearer $(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" \
     -H "Content-Type: application/vnd.api+json" \
     -X POST \
-    -d '{"data":{"type":"vars","attributes":{"key":"google_credentials","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n' | base64)'","description":"Base64 encoded GCP Service Account used to manage GCP resources","category":"terraform","sensitive":true}}}' \
+    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n' | base64)'","description":"Base64 encoded GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
 # Remove the Service Account Key from the local filesystem now that it has been

--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -51,14 +51,14 @@ gcloud beta billing projects link cloudshock-dev-$suffix --billing-account="bill
 gcloud projects list --filter "cloudshock-"
 
 # Create a single Service Account in the restricted project
-gcloud iam service-accounts create gcp-project --description "Service Account used by gcp-project to manage resources" --project cloudshock-$suffix > /dev/null
+gcloud iam service-accounts create tc-bootstrap --description "Service Account used by Terraform Cloud to run bootstrap project" --project cloudshock-$suffix > /dev/null
 
 # Give the single Service Account the Owner role in both projects
-gcloud projects add-iam-policy-binding cloudshock-$suffix --member=serviceAccount:gcp-project@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner > /dev/null
-gcloud projects add-iam-policy-binding cloudshock-dev-$suffix --member=serviceAccount:gcp-project@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner > /dev/null
+gcloud projects add-iam-policy-binding cloudshock-$suffix --member=serviceAccount:tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner > /dev/null
+gcloud projects add-iam-policy-binding cloudshock-dev-$suffix --member=serviceAccount:tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner > /dev/null
 
 # Create a Key for the Service Account
-gcloud iam service-accounts keys create .config/gcloud/gcp-project-credentials.json --iam-account=gcp-project@cloudshock-$suffix.iam.gserviceaccount.com > /dev/null
+gcloud iam service-accounts keys create ./gcp-credentials.json --iam-account=tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com > /dev/null
 
 terraform login
 
@@ -102,17 +102,17 @@ curl -sfL \
     -d '{"data":{"type":"vars","attributes":{"key":"TFE_TOKEN","value":"'$organization_token'","description":"Terraform Cloud Organization API Token used to configure Workspaces","category":"env","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
-# CReate the google_credentials Terraform Cloud Workspace Variable
+# Create the GOOGLE_CREDENTIALS Terraform Cloud Workspace Variable
 curl -sfL \
     -H "Authorization: Bearer $(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" \
     -H "Content-Type: application/vnd.api+json" \
     -X POST \
-    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "$HOME/.config/gcloud/gcp-project-credentials.json" | tr -d '\n')'","description":"GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
+    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "./gcp-credentials.json" | tr -d '\n')'","description":"GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
 # Remove the Service Account Key from the local filesystem now that it has been
 # used to create the Terraform Cloud Workspace Variable.
-rm -f "$HOME/.config/gcloud/gcp-project-credentials.json" > /dev/null || true
+rm -f "./gcp-credentials.json" > /dev/null || true
 
 # Import the bootstrap Terraform Cloud Workspace resource into the Terraform
 # State to avoid Terraform trying to create a second Workspace with the same

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -29,6 +29,18 @@ locals {
   ]
 }
 
-#resource "google_project_service" "cloudshock" {
-#
-#}
+resource "google_project_service" "cloudshock" {
+  for_each = toset(local.gcp_services)
+
+  project = "cloudshock-${var.gcp_project_suffix}"
+  service = each.value
+}
+
+resource "google_project_service" "cloudshock_dev" {
+  for_each = toset(local.gcp_services)
+
+  project = "cloudshock-dev-${var.gcp_project_suffix}"
+  service = each.value
+}
+
+

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -13,10 +13,22 @@
 provider "google" {
 }
 
-variable "gcp_projects" {
-  description = "The list of GCP Projects (Project ID) to configure."
-  type        = set(string)
-  default     = ["cloudshock-dev-344990", "cloudshock-344990",]
+variable "gcp_project_suffix" {
+  description = "The common suffix used for all GCP Project IDs."
+  type        = string
+  default     = "344990"
 }
 
-#resource "google_project_service" "cloudshock" {}
+locals {
+  gcp_project_ids = [
+    "cloudshock-${var.gcp_project_suffix}",
+    "cloudshock-dev-${var.gcp_project_suffix}",
+  ]
+  gcp_services = [
+    "compute.googleapis.com",
+  ]
+}
+
+#resource "google_project_service" "cloudshock" {
+#
+#}

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -43,4 +43,3 @@ resource "google_project_service" "cloudshock_dev" {
   service = each.value
 }
 
-

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -43,3 +43,37 @@ resource "google_project_service" "cloudshock_dev" {
   service = each.value
 }
 
+data "google_service_account" "tc_bootstrap" {
+  account_id = "tc-bootstrap"
+  project    = "cloudshock-${var.gcp_project_suffix}"
+}
+
+resource "google_project_iam_custom_role" "bootstrap" {
+  for_each = toset(local.gcp_project_ids)
+
+  role_id     = "terraformCloudBootstrap"
+  title       = "Terraform Cloud Bootstrap"
+  stage       = "GA"
+  description = "Custom Role used by Terraform Cloud for the bootstrap Workspace"
+
+  permissions = [
+    "iam.roles.create",
+    "iam.roles.delete",
+    "iam.roles.get",
+    "iam.roles.list",
+    "iam.roles.update",
+    "resourcemanager.projects.getIamPolicy",
+    "resourcemanager.projects.setIamPolicy",
+  ]
+}
+
+resource "google_project_iam_binding" "tc_bootstrap" {
+  for_each = toset(local.gcp_project_ids)
+
+  project = each.value
+  role    = google_project_iam_custom_role.bootstrap.name
+
+  members = [
+    "serviceAccount:${google_service_account.tc_bootstrap.email}",
+  ]
+}

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -26,6 +26,7 @@ locals {
   ]
   gcp_services = [
     "compute.googleapis.com",
+    "iam.googleapis.com",
   ]
 }
 
@@ -43,37 +44,37 @@ resource "google_project_service" "cloudshock_dev" {
   service = each.value
 }
 
-data "google_service_account" "tc_bootstrap" {
-  account_id = "tc-bootstrap"
-  project    = "cloudshock-${var.gcp_project_suffix}"
-}
+# data "google_service_account" "tc_bootstrap" {
+#   account_id = "tc-bootstrap"
+#   project    = "cloudshock-${var.gcp_project_suffix}"
+# }
 
-resource "google_project_iam_custom_role" "bootstrap" {
-  for_each = toset(local.gcp_project_ids)
+# resource "google_project_iam_custom_role" "bootstrap" {
+#   for_each = toset(local.gcp_project_ids)
 
-  role_id     = "terraformCloudBootstrap"
-  title       = "Terraform Cloud Bootstrap"
-  stage       = "GA"
-  description = "Custom Role used by Terraform Cloud for the bootstrap Workspace"
+#   role_id     = "terraformCloudBootstrap"
+#   title       = "Terraform Cloud Bootstrap"
+#   stage       = "GA"
+#   description = "Custom Role used by Terraform Cloud for the bootstrap Workspace"
 
-  permissions = [
-    "iam.roles.create",
-    "iam.roles.delete",
-    "iam.roles.get",
-    "iam.roles.list",
-    "iam.roles.update",
-    "resourcemanager.projects.getIamPolicy",
-    "resourcemanager.projects.setIamPolicy",
-  ]
-}
+#   permissions = [
+#     "iam.roles.create",
+#     "iam.roles.delete",
+#     "iam.roles.get",
+#     "iam.roles.list",
+#     "iam.roles.update",
+#     "resourcemanager.projects.getIamPolicy",
+#     "resourcemanager.projects.setIamPolicy",
+#   ]
+# }
 
-resource "google_project_iam_binding" "tc_bootstrap" {
-  for_each = toset(local.gcp_project_ids)
+# resource "google_project_iam_binding" "tc_bootstrap" {
+#   for_each = toset(local.gcp_project_ids)
 
-  project = each.value
-  role    = google_project_iam_custom_role.bootstrap.name
+#   project = each.value
+#   role    = google_project_iam_custom_role.bootstrap[each.value].name
 
-  members = [
-    "serviceAccount:${google_service_account.tc_bootstrap.email}",
-  ]
-}
+#   members = [
+#     "serviceAccount:${data.google_service_account.tc_bootstrap.email}",
+#   ]
+# }

--- a/terraform/tfe.tf
+++ b/terraform/tfe.tf
@@ -33,30 +33,3 @@ resource "tfe_workspace" "bootstrap" {
     oauth_token_id = var.terraform_cloud_oauth_token_id
   }
 }
-
-resource "tfe_workspace" "gcp_project" {
-  for_each = toset(var.gcp_projects)
-
-  name               = "gcp-project-${each.value}"
-  description        = "Configures GCP Project ${each.value}"
-  organization       = "cloudshock"
-  allow_destroy_plan = false
-  terraform_version  = "0.15.1"
-  queue_all_runs     = false
-}
-
-resource "tfe_variable" "google_credentials" {
-  for_each = toset(var.gcp_projects)
-
-  key          = "GOOGLE_CREDENTIALS"
-  value        = base64decode(var.google_credentials)
-  category     = "env"
-  workspace_id = tfe_workspace.gcp_project[each.value].id
-  description  = "GCP Service Account used to manage GCP resources"
-  sensitive    = true
-}
-
-variable "google_credentials" {
-  description = "value"
-  type        = string
-}


### PR DESCRIPTION
This Pull Request is a first step in addressing Issue #5.

It removes the Terraform Cloud Workspaces created for an anticipated gcp-project repository.  The Terraform configuration that was going to be managed in that repository will be managed from this one instead.

In this first step, the IAM API is enabled in all GCP projects.  Also, the GCP Service Account created in the **initial-setup.sh** script has been renamed from `gcp-project` to `tc-bootstrap`.  The `tc-` prefix will be used for all GCP Service Accounts created for use in Terraform Cloud.

A few additional improvements are also made in this change.
* Using a better location to temporarily store the downloaded Service Account Key
* Renaming the **gcp_projects** variable to `gcp_project_suffix` to streamline the process of update if the GCP Project ID suffix changes
