### PR TITLE
enabling cloudresourcemanager.googleapis.com for all GCP projects

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -27,6 +27,7 @@ locals {
   gcp_services = [
     "compute.googleapis.com",
     "iam.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
This Pull Request addresses the failed Terraform run following the merging of Pull Request #6 .

It enables the **cloudresourcemanager.googleapis.com** Service API for all GCP projects.