### PR TITLE
Downgrading Terraform Cloud Service Account from Owner to Custom Role

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -45,37 +45,37 @@ resource "google_project_service" "cloudshock_dev" {
   service = each.value
 }
 
-# data "google_service_account" "tc_bootstrap" {
-#   account_id = "tc-bootstrap"
-#   project    = "cloudshock-${var.gcp_project_suffix}"
-# }
+data "google_service_account" "tc_bootstrap" {
+  account_id = "tc-bootstrap"
+  project    = "cloudshock-${var.gcp_project_suffix}"
+}
 
-# resource "google_project_iam_custom_role" "bootstrap" {
-#   for_each = toset(local.gcp_project_ids)
+resource "google_project_iam_custom_role" "bootstrap" {
+  for_each = toset(local.gcp_project_ids)
 
-#   role_id     = "terraformCloudBootstrap"
-#   title       = "Terraform Cloud Bootstrap"
-#   stage       = "GA"
-#   description = "Custom Role used by Terraform Cloud for the bootstrap Workspace"
+  role_id     = "terraformCloudBootstrap"
+  title       = "Terraform Cloud Bootstrap"
+  stage       = "GA"
+  description = "Custom Role used by Terraform Cloud for the bootstrap Workspace"
 
-#   permissions = [
-#     "iam.roles.create",
-#     "iam.roles.delete",
-#     "iam.roles.get",
-#     "iam.roles.list",
-#     "iam.roles.update",
-#     "resourcemanager.projects.getIamPolicy",
-#     "resourcemanager.projects.setIamPolicy",
-#   ]
-# }
+  permissions = [
+    "iam.roles.create",
+    "iam.roles.delete",
+    "iam.roles.get",
+    "iam.roles.list",
+    "iam.roles.update",
+    "resourcemanager.projects.getIamPolicy",
+    "resourcemanager.projects.setIamPolicy",
+  ]
+}
 
-# resource "google_project_iam_binding" "tc_bootstrap" {
-#   for_each = toset(local.gcp_project_ids)
+resource "google_project_iam_binding" "tc_bootstrap" {
+  for_each = toset(local.gcp_project_ids)
 
-#   project = each.value
-#   role    = google_project_iam_custom_role.bootstrap[each.value].name
+  project = each.value
+  role    = google_project_iam_custom_role.bootstrap[each.value].name
 
-#   members = [
-#     "serviceAccount:${data.google_service_account.tc_bootstrap.email}",
-#   ]
-# }
+  members = [
+    "serviceAccount:${data.google_service_account.tc_bootstrap.email}",
+  ]
+}


### PR DESCRIPTION
This Pull Request is the next step in addressing Issue #5, by introducing an appropriate Custom Role in each of the GCP projects and adding a binding to it for the Service Account used by Terraform Cloud to execute Terraform runs.