### PR TITLE
Issue 10/minor edits to initial setup procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ GCP Projects are identified in two ways:
 
 By convention, project names will use all uppercase letters and hyphens, and project IDs will be the same as the name but using only lowercase letters and followed by a hyphen and a six digit sequence.  Since APIs and tools refer to GCP Projects by their ID not their name, the name is never used elsewhere (e.g. as part of the name of other resources).  Whenever a reference back to the GCP Project is needed, the Project ID is used.
 
-Currently, the projects have been created with the following attributes, however if reconstructing them in a disaster recovery scenario, it is possible that these project ID values are no longer available, in which case, a different six digit sequence should be used and the corresponding variable named **gcp_project_suffix** in the **terraform/gcp.tf** file and this README should be updated.
+Currently, the projects have been created with the following attributes, however if reconstructing them in a disaster recovery scenario, it is possible that these project ID values are no longer available, in which case, a different six digit sequence should be used and the corresponding variable named **gcp_project_suffix** in the **terraform/variables.tf** file and the table below should be updated.
 
 | Project Name   | Project ID            | Purpose            |
 | -------------- | --------------------- | ------------------ |
-| CLOUDSHOCK     | cloudshock-344990     | restricted project |
-| CLOUDSHOCK-DEV | cloudshock-dev-344990 | developer project  |
+| CLOUDSHOCK     | cloudshock-900334     | restricted project |
+| CLOUDSHOCK-DEV | cloudshock-dev-900334 | developer project  |
 
 #### GCP Service Account
 
@@ -54,12 +54,6 @@ The Service Account is the entity that Terraform runs authenticate as to update 
 Terraform Cloud is a system that can be used to executes Terraform runs in the cloud or locally, but handles the storage of the resulting Terraform State files in either case.
 
 This repository actually contains Terraform configuration to create all of the necessary Terraform Cloud Workspaces, however a few resources need to be created ahead time to allow the Terraform run that configures the rest.
-
-The **terraform-cloud.sh** script in the **scripts** directory completes the Terraform Cloud related initial setup.  The script requires some interaction with the operator at the beginning.  It is important that the **gcp-projects.sh** script, described in the previous section, gets executed before the **terraform-cloud.sh** script, since there is a dependency between the two scripts.  At the beginning of the script some interactions with the operator will occur.  The operator will be asked to accept that the Terraform Cloud User API Token will be stored unencrypted on the local filesystem.  Next, the operator will be asked for a description for the User API Token being created.  **The operator should replace the suggested description with `cloudshock` and then click the Create API token button.**.  The remaining setup is done without any further interaction.
-
-```sh
-scripts/terraform-cloud.sh
-```
 
 #### Terraform Cloud Organization
 

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -13,12 +13,6 @@
 provider "google" {
 }
 
-variable "gcp_project_suffix" {
-  description = "The common suffix used for all GCP Project IDs."
-  type        = string
-  default     = "344990"
-}
-
 locals {
   gcp_project_ids = [
     "cloudshock-${var.gcp_project_suffix}",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,3 +13,10 @@ variable "terraform_cloud_oauth_token_id" {
     default     = "ot-gU64RbHvGesz6Etk"
     type        = string
 }
+
+variable "gcp_project_suffix" {
+  description = "The common suffix used for all GCP Project IDs."
+  type        = string
+  default     = "900334"
+}
+


### PR DESCRIPTION
This Pull Request addresses some minor issues uncovered when preparing for re-running the Initial Setup procedure as called for in Issue #10.

## Changes
Now that a variables.tf file exists, the **gcp_project_suffix** variable, currently defined in the **gcp.tf** file, should be moved to the **variables.tf** file, since that is the widely adopted convention in Terraform projects and modules.

The README.md file still contained a paragraph describing the replaced **terraform-cloud.sh** script, including the command to launch that script.  Since the information was already duplicated into the paragraph explaining the now combined **initial-setup.sh** script, this unnecessary paragraph and code block were simply removed.

Since the current GCP Project ID suffix will need to change (Projects take 30 days to fully delete in GCP), the **gcp_project_suffix** variable value as well as the table in the **README.md** file were updated to the new value. 