### PR TITLE
Fixing Docker Error in initial-setup.sh Script

### DIFF
--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -12,7 +12,7 @@ set -eu${DEBUG:+x}o pipefail
 
 base_directory="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null ; pwd -P)"
 
-temp_directory=$(mktemp -d './tmpXXXXXX')
+temp_directory=$(mktemp -d "$base_directory/tmpXXXXXX")
 trap "rm -rf $temp_directory" EXIT
 
 source "$base_directory/functions.sh"


### PR DESCRIPTION
This Pull Request fixes Issue #12.

By using the value of the **base_directory** variable (an absolute path) as part of the pathname pattern, the pathname returned by **mktemp** is also an absolute path.  As an added benefit, this change also ensures that the temporary directory always gets created under the **bootstrap/scripts** directory, regardless of where the **initial-setup.sh** script is invoked from.
