### PR TITLE
Wrapped pipeline that transforms credentials file in quotes and escap…

### DIFF
--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -110,7 +110,7 @@ curl -sfL \
     -H "Authorization: Bearer $(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" \
     -H "Content-Type: application/vnd.api+json" \
     -X POST \
-    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'$(cat "$temp_directory/gcp-credentials.json" | tr -d '\n')'","description":"GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
+    -d '{"data":{"type":"vars","attributes":{"key":"GOOGLE_CREDENTIALS","value":"'"$(cat "$temp_directory/gcp-credentials.json" | tr -d '\n' | sed -e 's~"~\\"~g' -e 's~\\n~\\\\n~g')"'","description":"GCP Service Account used to manage GCP resources","category":"env","sensitive":true}}}' \
     https://app.terraform.io/api/v2/workspaces/$workspace_id/vars > /dev/null
 
 # Remove the Service Account Key from the local filesystem now that it has been
@@ -123,4 +123,3 @@ rm -f "$temp_directory/gcp-credentials.json" > /dev/null || true
 cd $base_directory/../terraform/
 terraform init > /dev/null
 TFE_TOKEN="$(jq -r '.credentials."app.terraform.io".token' ~/.terraform.d/credentials.tfrc.json)" terraform import tfe_workspace.bootstrap "$workspace_id" > /dev/null
-terraform plan -target=tfe_workspace.bootstrap -detailed-exitcode > /dev/null


### PR DESCRIPTION
This Pull Request addresses Issue #14 

When the **initial-setup.sh** script was modified to create an environment variable instead of a Terraform variable and its content was no longer base64 encoded, it broke the script.  Because the `-d` argument for the curl command uses single quotes to capture it's value, the quoting was suspended, so that a sub-shell `$(` and `)` could be processed in the middle.  However, when the output of that sub-shell was a base64 encoded value, it was impossible that a space be present, which made the approach fine.  Now that the value is not base64 encoded, and moreover it's a JSON value, several problems arise.  First, any spaces in the JSON encoded value are seen as a break in the value for the `-d` argument and the beginning of the next command line argument.  Second, the JSON encoded text of the value is interfering with the surrounding JSON encoded text of the request body.

To deal with the first issue, After suspending the single quote quotation, a double quote quotation was started to surround the output of the sub-shell.
```
-d '{"data":{... ,"value":"'"$( ... )"'",...}'
   ^                       ^^        ^^      ^
   |                       ||        ||      \-- end of single quote quotation
   |                       ||        |+-- beginning of single quote quotation
   |                       ||        +-- end of double quote quotation
   |                       |+ beginning of double quote quotation
   |                       +-- end of single quote quotation
   +-- beginning of single quote quotation
```
  To deal with the second issue, an additional pipeline step was added to the sub-shell to transform all occurrences of double quotes into a backslash-double quote sequence.
`"` --> `\"`

Finally, there was an issue with the backslash-n sequences in the PEM encoded portion of the value.  The escaping was lost by the time it would reach the server, so those sequences needed to be double escaped.
`\n` --> `\\n`

The final terraform plan command was initially meant as a simplistic verification test that everything went well with the import, but since the Terraform configuration now adds the VCS integration configuration, that resource will always show a diff.  Given that, there was little reason to keep it.