### PR TITLE
Adding the cloudkms.googleapis.com Service API

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -22,6 +22,7 @@ locals {
     "compute.googleapis.com",
     "iam.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "cloudkms.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
This Pull Request enables the Cloud Key Management Service (KMS) Service API for each of the GCP projects.