### PR TITLE
Removing the cloudkms.location permissions, and adding unrestricted k…

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -60,8 +60,6 @@ resource "google_project_iam_custom_role" "bootstrap" {
     "cloudkms.keyRings.getIamPolicy",
     "cloudkms.keyRings.list",
     "cloudkms.keyRings.setIamPolicy",
-    "cloudkms.locations.get",
-    "cloudkms.locations.list",
     "iam.roles.create",
     "iam.roles.delete",
     "iam.roles.get",
@@ -81,4 +79,36 @@ resource "google_project_iam_binding" "tc_bootstrap" {
   members = [
     "serviceAccount:${data.google_service_account.tc_bootstrap.email}",
   ]
+}
+
+resource "google_kms_key_ring" "us" {
+  for_each = toset(local.gcp_project_ids)
+
+  name     = "unrestricted"
+  location = "us"
+  project  = each.key
+}
+
+resource "google_kms_key_ring" "europe" {
+  for_each = toset(local.gcp_project_ids)
+
+  name     = "unrestricted"
+  location = "eur4"
+  project  = each.key
+}
+
+resource "google_kms_key_ring" "australia" {
+  for_each = toset(local.gcp_project_ids)
+
+  name     = "unrestricted"
+  location = "australia-southeast-1"
+  project  = each.key
+}
+
+resource "google_kms_key_ring" "asia" {
+  for_each = toset(local.gcp_project_ids)
+
+  name     = "unrestricted"
+  location = "asia1"
+  project  = each.key
 }

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -65,6 +65,7 @@ resource "google_project_iam_custom_role" "bootstrap" {
     "iam.roles.get",
     "iam.roles.list",
     "iam.roles.update",
+    "iam.serviceAccounts.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.projects.setIamPolicy",
   ]


### PR DESCRIPTION
This Pull Request resolves Issue #21 by adding a Cloud KMS Key Ring named **unrestricted** in each of the following geographies:
* us
* eur4
* asia1
* australia-southeast-1
For each of the GCP Projects.

GCP KMS allows key rings with the same name in different locations.  This will allow downstream components that need crypto keys to simply need to be aware of which of the key ring location they use in order to construct the resource ID of the key ring or even the crypto key.

The **cloudkms.locations.get** and **cloudkms.locations.list** permissions are also being removed, since they are not needed by the Terraform project.