### PR TITLE
Fixing Typo in Australia Location

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -106,7 +106,7 @@ resource "google_kms_key_ring" "australia" {
   for_each = toset(local.gcp_project_ids)
 
   name     = "unrestricted"
-  location = "australia-southeast-1"
+  location = "australia-southeast1"
   project  = each.key
 }
 


### PR DESCRIPTION
This Pull Request fixes a typo in the location specified for the Australia Key Ring.