### PR TITLE
Add gce-images Terraform Cloud Workspace

### DIFF
--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -66,6 +66,7 @@ resource "google_project_iam_custom_role" "bootstrap" {
     "iam.roles.list",
     "iam.roles.update",
     "iam.serviceAccounts.get",
+    "resourcemanager.projects.get",
     "resourcemanager.projects.getIamPolicy",
     "resourcemanager.projects.setIamPolicy",
     "serviceusage.services.disable",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,7 +18,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.66.1"
+      version = "~> 3.67"
     }
   }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,14 @@
+################################################################################
+#
+# bootstrap
+#   A Terraform project to provision the resources needed to deploy the project.
+#
+# outputs.tf
+#   Defines the output variables for the project.
+#
+################################################################################
+
+output "project_suffix" {
+    description = "The six-digit sequence used as the suffix for all GCP Projects."
+    value       = var.project_suffix
+}

--- a/terraform/tfe.tf
+++ b/terraform/tfe.tf
@@ -53,4 +53,3 @@ resource "tfe_workspace" "gce_images" {
     oauth_token_id = var.terraform_cloud_oauth_token_id
   }
 }
-

--- a/terraform/tfe.tf
+++ b/terraform/tfe.tf
@@ -33,3 +33,23 @@ resource "tfe_workspace" "bootstrap" {
     oauth_token_id = var.terraform_cloud_oauth_token_id
   }
 }
+
+resource "tfe_workspace" "gce_images" {
+  name               = "gce-images"
+  description        = "Configures resources required to build GCE Images"
+  organization       = "cloudshock"
+  allow_destroy_plan = false
+  terraform_version  = "0.15.1"
+  queue_all_runs     = false
+  working_directory  = "terraform/"
+
+  trigger_prefixes = [
+    "terraform/",
+  ]
+
+  vcs_repo {
+    identifier     = "cloudshock/gce-images"
+    branch         = "main"
+    oauth_token_id = var.terraform_cloud_oauth_token_id
+  }
+}

--- a/terraform/tfe.tf
+++ b/terraform/tfe.tf
@@ -53,3 +53,4 @@ resource "tfe_workspace" "gce_images" {
     oauth_token_id = var.terraform_cloud_oauth_token_id
   }
 }
+


### PR DESCRIPTION
This Pull Request addresses Issue #26 by adding a Terraform Cloud Workspace named gce-images to manage Terraform runs from the [gce-images](https://github.com/cloudshock/gce-images) repository.

The Pull Request also includes a few related modifications:
* Loosened the required version for the google provider:
   By dropping the third number from the constraint, it allows a broader range of valid versions.  `~> 3.66.1` allowed every version of the pattern 3.66.x.  Whereas, specifying `~> 3.67` allows every version of the pattern 3.x.y.
* Added an output variable for the project_suffix:
   Downstream Terraform projects will need to specify the GCP Project ID in their configuration, so they need to know what project_suffix sequence is used by this Terraform project.