### PR TITLE
Adding Images GCP Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As part of the creating the GCP Account, a Billing Account was setup.  This Bill
 
 The initial setup script for GCP creates two GCP Projects, links a GCP Billing Account to them, creates a GCP Service Account (in one of the GCP Projects), grants this Service Account the Owner role in both GCP Projects, and finally generates a Key for the GCP Service Account.
 
-The two GCP Projects created are: a restricted project where the production and pre-production deployments exist, as well as released assets like Google Compute Engine (GCE) Images and Docker Images; the other project is used by developers to deploy their own deployments or partial deployments to experiment, validate, and test, prior to commiting their changes to the main branches of the code repositories.
+The three GCP Projects created are: a restricted project where the production and pre-production deployments exist, the next project is used by developers to deploy their own deployments or partial deployments to experiment, validate, and test, prior to commiting their changes to the main branches of the code repositories, and the final project is where GCE Images are built and hosted.
 
 GCP Projects are identified in two ways:
 * Name: a display name for the project
@@ -38,10 +38,11 @@ By convention, project names will use all uppercase letters and hyphens, and pro
 
 Currently, the projects have been created with the following attributes, however if reconstructing them in a disaster recovery scenario, it is possible that these project ID values are no longer available, in which case, a different six digit sequence should be used and the corresponding variable named **gcp_project_suffix** in the **terraform/variables.tf** file and the table below should be updated.
 
-| Project Name   | Project ID            | Purpose            |
-| -------------- | --------------------- | ------------------ |
-| CLOUDSHOCK     | cloudshock-445899     | restricted project |
-| CLOUDSHOCK-DEV | cloudshock-dev-445899 | developer project  |
+| Project Name      | Project ID               | Purpose            |
+| ----------------- | ------------------------ | ------------------ |
+| CLOUDSHOCK        | cloudshock-445899        | restricted project |
+| CLOUDSHOCK-DEV    | cloudshock-dev-445899    | developer project  |
+| CLOUDSHOCK-IMAGES | cloudshock-images-445899 | images project     |
 
 #### GCP Service Account
 

--- a/scripts/initial-setup.sh
+++ b/scripts/initial-setup.sh
@@ -52,9 +52,11 @@ done
 
 gcloud projects create cloudshock-$suffix --name CLOUDSHOCK --labels="creation-repository=bootstrap,persistent=true,created-by=$(whoami)"
 gcloud projects create cloudshock-dev-$suffix --name CLOUDSHOCK-DEV --labels="creation-repository=bootstrap,persistent=true,created-by=$(whoami)"
+gcloud projects create cloudshock-images-$suffix --name CLOUDSHOCK-IMAGES --labels="creation-repository=bootstrap,persistent=true,create-by=$(whoami)"
 
 gcloud beta billing projects link cloudshock-$suffix --billing-account="billingAccounts/$billing_account"
 gcloud beta billing projects link cloudshock-dev-$suffix --billing-account="billingAccounts/$billing_account"
+gcloud beta billing projects link cloudshock-images-$suffix --billing-account="billingAccounts/$billing_account"
 
 gcloud projects list --filter "cloudshock-"
 
@@ -64,6 +66,7 @@ gcloud iam service-accounts create tc-bootstrap --description "Service Account u
 # Give the single Service Account the Owner role in both projects
 gcloud projects add-iam-policy-binding cloudshock-$suffix --member=serviceAccount:tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner
 gcloud projects add-iam-policy-binding cloudshock-dev-$suffix --member=serviceAccount:tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner
+gcloud projects add-iam-policy-binding cloudshock-images-$suffix --member=serviceAccount:tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com --role=roles/owner
 
 # Create a Key for the Service Account
 gcloud iam service-accounts keys create /data/gcp-credentials.json --iam-account=tc-bootstrap@cloudshock-$suffix.iam.gserviceaccount.com
@@ -141,6 +144,7 @@ if [[ ${CLOUDSHOCK_TEST:+x} == x ]] ; then
 
     gcloud projects delete cloudshock-dev-$suffix
     gcloud projects delete cloudshock-$suffix
+    gcloud projects delete cloudshock-images-$suffix
 
     exit 0
 else

--- a/terraform/gcp.tf
+++ b/terraform/gcp.tf
@@ -17,26 +17,48 @@ locals {
   gcp_project_ids = [
     "cloudshock-${var.project_suffix}",
     "cloudshock-dev-${var.project_suffix}",
+    "cloudshock-images-${var.project_suffix}",
   ]
-  gcp_services = [
-    "compute.googleapis.com",
-    "iam.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "cloudkms.googleapis.com",
-  ]
+  gcp_services = {
+    "cloudshock" = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "cloudkms.googleapis.com",
+    ]
+    "cloudshock-dev" = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "cloudkms.googleapis.com",
+    ]
+    "cloudshock-images" = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "cloudkms.googleapis.com",
+    ]
+  }
 }
 
 resource "google_project_service" "cloudshock" {
-  for_each = toset(local.gcp_services)
+  for_each = toset(local.gcp_services["cloudshock"])
 
   project = "cloudshock-${var.project_suffix}"
   service = each.value
 }
 
 resource "google_project_service" "cloudshock_dev" {
-  for_each = toset(local.gcp_services)
+  for_each = toset(local.gcp_services["cloudshock-dev"])
 
   project = "cloudshock-dev-${var.project_suffix}"
+  service = each.value
+}
+
+resource "google_project_service" "cloudshock_images" {
+  for_each = toset(local.gcp_services["cloudshock-images"])
+
+  project = "cloudshock-images-${var.project_suffix}"
   service = each.value
 }
 


### PR DESCRIPTION
This Pull Request moves towards resolving Issue #26.

The changes include adding explanation of Images GCP project in README.md file, adding commands in **initial-setup.sh** script to create the Images project, link it to the billing account, and add IAM binding for the **tc-bootstrap** Service Account as having the **Owner** role in the Images project.